### PR TITLE
Change gds to cod-cli

### DIFF
--- a/.github/workflows/test-bot.yml
+++ b/.github/workflows/test-bot.yml
@@ -2,10 +2,10 @@ name: brew test-bot
 on:
   pull_request:
     paths:
-      - "Formula/gds-cli.rb"
+      - "Formula/cod-cli.rb"
   push:
     paths:
-      - "Formula/gds-cli.rb"
+      - "Formula/cod-cli.rb"
   workflow_dispatch:
 jobs:
   test-bot:
@@ -19,8 +19,8 @@ jobs:
         run: |
           set -e
           brew update
-          HOMEBREW_TAP_DIR="/usr/local/Homebrew/Library/Taps/alphagov/homebrew-gds"
+          HOMEBREW_TAP_DIR="/usr/local/Homebrew/Library/Taps/govwifi/homebrew-cod"
           mkdir -p "$HOMEBREW_TAP_DIR"
           rm -rf "$HOMEBREW_TAP_DIR"
           ln -s "$PWD" "$HOMEBREW_TAP_DIR"
-          brew test-bot gds-cli
+          brew test-bot cod-cli

--- a/Formula/gds-cli.rb
+++ b/Formula/gds-cli.rb
@@ -1,11 +1,11 @@
-class GdsCli < Formula
-  desc "CLI for common commands used by Government Digital Service staff"
-  homepage "https://github.com/alphagov/gds-cli"
-  url "git@github.com:alphagov/gds-cli.git",
+class CodCli < Formula
+  desc "CLI for common commands used by CO Digital staff"
+  homepage "https://github.com/govwifi/cod-cli"
+  url "git@github.com:govwifi/cod-cli.git",
       using:    :git,
       tag:      "v5.112.0",
       revision: "3247f57d0f2f4241b7a9bd975c383881d3339921"
-  head "git@github.com:alphagov/gds-cli.git",
+  head "git@github.com:govwifi/cod-cli.git",
       using:  :git,
       branch: "main"
 
@@ -20,29 +20,29 @@ class GdsCli < Formula
 
     system "make"
 
-    bin.install "gds"
-    bin.install_symlink("gds" => "gds-cli")
+    bin.install "cod"
+    bin.install_symlink("cod" => "cod-cli")
 
-    # Completion for `gds`
-    output = Utils.safe_popen_read("#{bin}/gds", "shell-completion", "bash")
-    (bash_completion/"gds").write output
-    output = Utils.safe_popen_read("#{bin}/gds", "shell-completion", "zsh")
-    (zsh_completion/"_gds").write output
+    # Completion for `cod`
+    output = Utils.safe_popen_read("#{bin}/cod", "shell-completion", "bash")
+    (bash_completion/"cod").write output
+    output = Utils.safe_popen_read("#{bin}/cod", "shell-completion", "zsh")
+    (zsh_completion/"_cod").write output
 
-    # Completion for `gds-cli`
-    output = Utils.safe_popen_read("#{bin}/gds-cli", "shell-completion", "bash")
-    (bash_completion/"gds-cli").write output
-    output = Utils.safe_popen_read("#{bin}/gds-cli", "shell-completion", "zsh")
-    (zsh_completion/"_gds-cli").write output
+    # Completion for `cod-cli`
+    output = Utils.safe_popen_read("#{bin}/cod-cli", "shell-completion", "bash")
+    (bash_completion/"cod-cli").write output
+    output = Utils.safe_popen_read("#{bin}/cod-cli", "shell-completion", "zsh")
+    (zsh_completion/"_cod-cli").write output
   end
 
   def caveats
     return if OS.linux?
 
-    "gds-cli depends on aws-vault being installed.  You can install it with `brew install --cask aws-vault`."
+    "cod-cli depends on aws-vault being installed.  You can install it with `brew install --cask aws-vault`."
   end
 
   test do
-    assert_match("USAGE", shell_output("#{bin}/gds"))
+    assert_match("USAGE", shell_output("#{bin}/cod"))
   end
 end

--- a/README.md
+++ b/README.md
@@ -1,25 +1,25 @@
 homebrew-gds
 ============
 
-A private Homebrew tap for the internal GDS CLI tooling, like the [gds-cli](https://github.com/alphagov/gds-cli).
+A private Homebrew tap for the internal COD CLI tooling, like the [cod-cli](https://github.com/govwifi/cod-cli).
 
-## GDS CLI
+## COD CLI
 
 ### Pre-requisites
 
-- An SSH key configured in GitHub, as the gds-cli repo clones over SSH.
+- An SSH key configured in GitHub, as the cod-cli repo clones over SSH.
 
 ### Usage
 
 ```
-brew tap alphagov/gds
-brew install gds-cli
-gds --version
+brew tap govwifi/cod
+brew install cod-cli
+cod --version
 ```
 
 or
 
 ```
-brew install alphagov/gds/gds-cli
-gds --version
+brew install govwifi/cod/cod-cli
+cod --version
 ```


### PR DESCRIPTION
Due to the impending GDS/COD split, CO Digital is cloning tools it has used whilst part of GDS so as not to loose access to essential tooling.