### PR TITLE
Additional changes to COD cli from original

### DIFF
--- a/.github/workflows/test-bot.yml
+++ b/.github/workflows/test-bot.yml
@@ -1,26 +1,34 @@
-name: brew test-bot
-on:
-  pull_request:
-    paths:
-      - "Formula/cod-cli.rb"
-  push:
-    paths:
-      - "Formula/cod-cli.rb"
-  workflow_dispatch:
-jobs:
-  test-bot:
-    runs-on: macos-latest
-    steps:
-      - name: Set up Git repository
-        uses: actions/checkout@v4
-        with:
-          show-progress: false
-      - name: Run brew test-bot
-        run: |
-          set -e
-          brew update
-          HOMEBREW_TAP_DIR="/usr/local/Homebrew/Library/Taps/govwifi/homebrew-cod"
-          sudo mkdir -p "$HOMEBREW_TAP_DIR"
-          sudo rm -rf "$HOMEBREW_TAP_DIR"
-          sudo ln -s "$PWD" "$HOMEBREW_TAP_DIR"
-          brew test-bot cod-cli
+# name: brew test-bot
+# on:
+#   pull_request:
+#     paths:
+#       - "Formula/cod-cli.rb"
+#   push:
+#     paths:
+#       - "Formula/cod-cli.rb"
+#   workflow_dispatch:
+
+# permissions:
+#   contents: read
+#   pull-requests: write
+
+# jobs:
+#   test-bot:
+#     runs-on: macos-latest
+#     steps:
+#       - name: Set up Git repository
+#         uses: actions/checkout@v4
+#         with:
+#           show-progress: false
+#       - name: Run brew test-bot
+#         run: |
+#           set -e
+#           brew update
+#           HOMEBREW_TAP_DIR="/usr/local/Homebrew/Library/Taps/govwifi/homebrew-cod"
+#           sudo mkdir -p "$HOMEBREW_TAP_DIR"
+#           sudo rm -rf "$HOMEBREW_TAP_DIR"
+#           sudo ln -s "$PWD" "$HOMEBREW_TAP_DIR"
+#           brew test-bot --tap=govwifi/cod cod-cli
+#         env:
+#           HOMEBREW_GITHUB_API_TOKEN: ${{ secrets.COD_TOKEN }}
+


### PR DESCRIPTION
**Disabled github actions workflow: test-bot.yml** 
On the [homebrew-gds repo](https://github.com/alphagov/homebrew-gds) which this repo was forked from, it appears that the test-bot.yml github action has been broken for at least a year. Since we are unsure if this action ever worked, or if it was a work in progress that has now been abandoned - we have commented it out.  The `brew test-bot command` is usually used to test the the formula using native brew commands and linters. However much of the linting is currently broken, and the brew test-bot is unable to clone the cod-cli repo, as this is a private repo that can only be reached by SSH. This problem is explained in more detail
below.

**SSH vs Https** 
Installing the cod cli via brew ( you can inspect the formula
here https://github.com/GovWifi/homebrew-cod/blob/master/Formula/cod-cli.rb) requires access to the cod-cli repo over SSH. This is also how [the gds-cli](https://github.com/alphagov/homebrew-gds) formula works. This is fine if a human user is pulling the code down as part of a brew install on their local machine, as they will have an SSH key associated to their account. However if a github action is pulling down the code, then it cannot use an SSH key, it MUST use a github token.

We experimented with setting a github token as value for HOMEBREW_GITHUB_API_TOKEN environment variable as suggested by the [brew test-bot help page](https://docs.brew.sh/Manpage#test-bot-options-formula)
( [please see line 33 of the formula](https://github.com/GovWifi/homebrew-cod/blob/add-make-new-tap/.github/workflows/test-bot.yml#L33) ). However we later discovered that Github tokens only work over https NOT SSH. So it does not seem possible to use the `brew test-bot` command to validate our
current formula.

**Final decision and possible future feature** 
Presently the cod-cli compiles and works fine without this extra testing step, and we are unable to dedicate
any more developer time to fixing the broken action. However, at some future point we may revisit this work, and perhaps refactor the formula or rewrite it in another language which offers more flexibility than ruby around cloning
repos using https.
